### PR TITLE
Fix the Red/Blue inversion while reading.

### DIFF
--- a/snxrom.py
+++ b/snxrom.py
@@ -321,7 +321,7 @@ class SNXRom:
                 for i in range(e.startEyeId, e.startEyeId + e.numberOfEyeFrames):
                     if i in eyeImages: continue
                     asset = (c_uint16 * (128*128)).from_buffer(content, assetTablePointers[i])
-                    eyeImages[i] = PIL.Image.frombytes('RGB', (128,128), string_at(asset, 128*128*2), 'raw', 'RGB;16')
+                    eyeImages[i] = PIL.Image.frombytes('RGB', (128,128), string_at(asset, 128*128*2), 'raw', 'BGR;16')
 
         return cls(storyId=0 if metadata is None else metadata.storyId, eyeAnimations=eyeAnimations, eyeImages=eyeImages, videoAudioSequences=videoAudioSequences, marks=marks, audioHeaders=audioHeaders, audioData=audioData)
 


### PR DESCRIPTION
Red and Blue colors were inverted when comparing the PNG generated from Intro.bin. They were also not marking the image made with ruxalyzer. Actually the code from ruxalyzer 

See: 
https://github.com/ladyada/Adafruit_Learning_System_Guides/blob/d8484666a50c11eff3ec6b4b598f6bfe62733071/Teddy_Ruxpin/ruxalyzer.py#L126C5-L126C5

This fix #2 for me.